### PR TITLE
Assistant checkpoint: PDF görüntüleme ve imleç kontrolü iyileştirildi

### DIFF
--- a/kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.html
+++ b/kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.html
@@ -18,8 +18,12 @@
         <button (click)="hizliRenkSec('#000000')" class="renk-btn siyah" [class.aktif]="kalemRengi === '#000000'" title="Siyah"></button>
       </div>
 
-      <button (click)="kalemModunuAc()" class="btn-modern" [class.aktif]="!silgiModu">
+      <button (click)="kalemModunuAc()" class="btn-modern" [class.aktif]="!silgiModu && cizilebilir">
         <i class="ikon">✏️</i> Kalem
+      </button>
+
+      <button (click)="toggleCizim()" class="btn-modern" [class.aktif]="!cizilebilir">
+        <i class="ikon">👆</i> İmleç {{cizilebilir ? 'Modu' : 'Modu'}}
       </button>
 
       <div class="kalem-boyutu">
@@ -36,7 +40,7 @@
       <button (click)="silgiModunuAc()" class="btn-modern" [class.aktif]="silgiModu">
         <i class="ikon">🧹</i> Silgi
       </button>
-      
+
       <button (click)="temizleCanvas()" class="btn-modern temizle">
         <i class="ikon">🗑️</i> Temizle
       </button>
@@ -96,12 +100,12 @@
         [zoom]="zoom"
         [stick-to-page]="false"
         (after-load-complete)="pdfYuklendiHandler($event)"
-        style="height: auto !important; width: 1200px !important; max-width: 100% !important; position: relative; display: block; min-height: 100%; margin: 0 auto; overflow-y: visible !important; margin-bottom: 100px !important;"
+        style="height: auto !important; width: 1400px !important; max-width: 100% !important; position: relative; display: block; min-height: 100%; margin: 0 auto; overflow-y: visible !important; margin-bottom: 100px !important;"
       ></pdf-viewer>
       <div class="canvas-wrapper">
         <canvas #canvas class="drawing-canvas"></canvas>
       </div>
-      
+
       <!-- Sayfalar arası geçiş için footer -->
       <div class="pdf-footer" [class.tam-ekran-footer]="tamEkranModu">
         <div class="footer-content">

--- a/kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.scss
+++ b/kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.scss
@@ -607,16 +607,17 @@
 ::ng-deep pdf-viewer {
   display: block !important;
   width: 100% !important;
-  height: auto !important; /* pdf'in yüksekliği içeriğine göre belirlensin */
-  min-height: 100% !important;
+  height: 1400px !important; /* Yüksekliği sabit 1400px olarak ayarla */
+  min-height: 1400px !important;
   background-color: white;
 
   .ng2-pdf-viewer-container {
     overflow: visible !important;
-    padding-bottom: 120px !important; /* Alt kısımda daha fazla boşluk bırak */
+    padding-bottom: 200px !important; /* Alt kısımda daha fazla boşluk bırak */
     display: flex !important;
     flex-direction: column !important;
     align-items: center !important;
+    height: 1400px !important;
   }
 
   .page {
@@ -655,6 +656,16 @@
   height: auto !important;
   margin: 20px auto !important;
   scroll-margin-top: 50px; /* Sayfa değiştirirken üstte boşluk bırak */
+  z-index: 1 !important; /* Sayfaların render sırasını düzelt */
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2) !important;
+  border-radius: 4px !important;
+  page-break-after: always !important;
+  padding-bottom: 50px !important;
+}
+
+/* Özel imleç modlarını belirginleştir */
+body:not(.kalem-aktif):not(.silgi-aktif) .drawing-canvas {
+  cursor: default !important;
 }
 
 /* Tüm sayfaların görünmesi için ekstra düzenleme */

--- a/kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.ts
+++ b/kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.ts
@@ -121,7 +121,16 @@ export class KonuAnlatimSayfalariComponent implements OnInit, AfterViewInit {
   pdfYuklendiHandler(event: any): void {
     this.totalPages = event.numPages;
     console.log('PDF sayfa sayısı:', this.totalPages);
-
+    
+    // PDF doğru yüklendiğini garanti et
+    const pdfContainer = document.querySelector('.pdf-container') as HTMLElement;
+    if (pdfContainer) {
+      // Yükseklik ayarlaması
+      const minHeight = this.totalPages * 800 + 500; // Her sayfa için minimum 800px + extra
+      pdfContainer.style.minHeight = `${minHeight}px`;
+      console.log('PDF konteyner minimum yüksekliği:', minHeight);
+    }
+    
     // Tüm sayfaları göstermek için currentPage değerini 1 olarak ayarla
     // PDF viewer'ın [show-all]="true" özelliği zaten tüm sayfaları gösterecektir
     this.currentPage = 1;
@@ -207,9 +216,9 @@ export class KonuAnlatimSayfalariComponent implements OnInit, AfterViewInit {
       setTimeout(() => {
         // Canvas elementi boyutlandırma - tüm PDF sayfalarını kapsayacak şekilde
         const canvasEl = this.canvasElement.nativeElement;
-        // Tüm sayfaları görebilmek için yeterli yükseklik belirle
+        // Tüm sayfaları görebilmek için daha fazla yükseklik belirle
         canvasEl.width = totalWidth;
-        canvasEl.height = Math.max(totalHeight, this.totalPages * 2000); // Her sayfa için yeterli alan arttırıldı
+        canvasEl.height = Math.max(totalHeight, this.totalPages * 3000); // Her sayfa için daha fazla alan
 
         console.log('Canvas boyutları:', totalWidth, 'x', totalHeight);
 
@@ -395,8 +404,17 @@ export class KonuAnlatimSayfalariComponent implements OnInit, AfterViewInit {
         document.body.classList.remove('silgi-aktif');
       }
     } else {
+      // Kalem ve silgi modlarını kapat, normal fare imleci kullan
       document.body.classList.remove('kalem-aktif', 'silgi-aktif');
+      
+      // Canvas imleç stilini güncelle
+      const upperCanvas = document.querySelector('.canvas-container .upper-canvas') as HTMLCanvasElement;
+      if (upperCanvas) {
+        upperCanvas.style.cursor = 'default'; // Normal imleç
+      }
     }
+    
+    console.log('Çizim modu değiştirildi:', this.cizilebilir ? 'Kalem/Silgi Aktif' : 'İmleç Aktif');
   }
 
   ayarlaKalemOzellikleri(): void {


### PR DESCRIPTION
Assistant generated file changes:
- kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.scss: PDF görüntüleme yüksekliğini 1400px yapma ve sayfa görünürlüğünü artırma, Tüm sayfaların düzgün görünmesi için ek stiller ve imleç modu için stil ekleme
- kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.ts: Canvas yüksekliğini artırma ve tüm sayfaların görünmesini sağlama, İmleç değiştirme mantığını düzeltme ve PDF görünme sorununu çözme, PDF yükleme ve görüntüleme ayarlarını düzeltme
- kimyaogreniyorum/src/app/components/yönetici-sayfalari/konu-anlatim-sayfalari/konu-anlatim-sayfalari.component.html: PDF genişliğini düzenleyip imleç geçiş kontrolü eklemek

---

User prompt:

pdf görüntüsünüde 1400 göre ayarla ve hala 3. sayfa ve diğerleri gözükmüyor. bide pdf de büyütünce bir yere dikkat etmek için kalemi birakıp mousa gönüşüp istediğim yere geçmek istiyorum

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 90e39176-7cc2-4e5f-a745-20a5b2e8d377